### PR TITLE
Get the http method from the correct place.

### DIFF
--- a/lambdas/soap/soap.py
+++ b/lambdas/soap/soap.py
@@ -33,7 +33,7 @@ soap_response_suffix = """
 
 def lambda_handler(event, context):
     print(event)
-    method = event["httpMethod"]
+    method = event['requestContext']['http']['method']
     if method == "GET":
         if "queryStringParameters" in event and event["queryStringParameters"]:
             query_params = {

--- a/lambdas/test/test_soap.py
+++ b/lambdas/test/test_soap.py
@@ -23,12 +23,12 @@ class SoapTest(unittest.TestCase):
             return mock_open(read_data="Test wsdl").return_value
 
     def test_return_404_if_header_missing(self):
-        response = soap.lambda_handler({"httpMethod": "POST", "headers": {}}, None)
+        response = soap.lambda_handler({"requestContext": {"http": {"method": "POST"}}, "headers": {}}, None)
         self.assertEqual(response["statusCode"], 404)
 
     def test_return_404_if_header_invalid(self):
         response = soap.lambda_handler(
-            {"httpMethod": "POST", "headers": {"soapaction": "invalid"}}, None
+            {"requestContext": {"http": {"method": "POST"}}, "headers": {"soapaction": "invalid"}}, None
         )
         self.assertEqual(response["statusCode"], 404)
 
@@ -40,7 +40,7 @@ class SoapTest(unittest.TestCase):
         mock_urlopen.return_value = mock_response
         action = "http://pronom.nationalarchives.gov.uk:getSignatureFileV1In"
         response = soap.lambda_handler(
-            {"httpMethod": "POST", "headers": {"soapaction": action}}, None
+            {"requestContext": {"http": {"method": "POST"}}, "headers": {"soapaction": action}}, None
         )
 
         expected_body = """<?xml version="1.0" encoding="utf-8"?>
@@ -62,7 +62,7 @@ Test String
     def test_return_version_file(self, _):
         action = "http://pronom.nationalarchives.gov.uk:getSignatureFileVersionV1In"
         response = soap.lambda_handler(
-            {"httpMethod": "POST", "headers": {"soapaction": action}}, None
+            {"requestContext": {"http": {"method": "POST"}}, "headers": {"soapaction": action}}, None
         )
         self.assertEqual(response["body"], "Test version file content")
         self.assertEqual(response["headers"]["Content-Type"], "text/xml")
@@ -70,7 +70,7 @@ Test String
 
     @patch("builtins.open", side_effect=open_mock_file)
     def test_return_soap_description(self, _):
-        response = soap.lambda_handler({"httpMethod": "GET"}, None)
+        response = soap.lambda_handler({"requestContext": {"http": {"method": "GET"}}}, None)
         self.assertEqual(response["body"], "Test soap description")
         self.assertEqual(response["headers"]["Content-Type"], "text/html")
         self.assertEqual(response["statusCode"], 200)
@@ -78,7 +78,7 @@ Test String
     @patch("builtins.open", side_effect=open_mock_file)
     def test_return_signature_file_description(self, _):
         event = {
-            "httpMethod": "GET",
+            "requestContext": {"http": {"method": "GET"}},
             "queryStringParameters": {"op": "getSignatureFileV1"},
         }
         response = soap.lambda_handler(event, None)
@@ -89,7 +89,7 @@ Test String
     @patch("builtins.open", side_effect=open_mock_file)
     def test_return_signature_file_version_description(self, _):
         event = {
-            "httpMethod": "GET",
+            "requestContext": {"http": {"method": "GET"}},
             "queryStringParameters": {"op": "getSignatureFileVersionV1"},
         }
         response = soap.lambda_handler(event, None)
@@ -99,7 +99,7 @@ Test String
 
     @patch("builtins.open", side_effect=open_mock_file)
     def test_return_wsdl(self, _):
-        event = {"httpMethod": "GET", "queryStringParameters": {"WSDL": ""}}
+        event = {"requestContext": {"http": {"method": "GET"}}, "queryStringParameters": {"WSDL": ""}}
         response = soap.lambda_handler(event, None)
         self.assertEqual(response["body"], "Test wsdl")
         self.assertEqual(response["headers"]["Content-Type"], "text/xml")


### PR DESCRIPTION
The old way is how API gateway sends it. This works for the function
urls.
