### PR TITLE
DR2-2788 Change trust policy of signature deploy role to only allow environments

### DIFF
--- a/bootstrap.json
+++ b/bootstrap.json
@@ -129,7 +129,7 @@
                 "StringLike": {
                   "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
                   "token.actions.githubusercontent.com:sub": [
-                    "repo:nationalarchives/pronom-signatures:ref:refs/heads/main"
+                    "repo:nationalarchives/pronom-signatures:environment:prod"
                   ]
                 }
               }


### PR DESCRIPTION
Zizmor had a finding which says that the role assumption should be
inside an environment.

I've changed the workflow job but I need to update the trust policy as
well.
