### PR TITLE
DR2-2793 Search fails on deploy.

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -64,7 +64,8 @@ resource "aws_lambda_permission" "cloudfront_invoke_results" {
   for_each      = toset(["InvokeFunction", "InvokeFunctionUrl"])
   statement_id  = "AllowCloudFront${each.value}"
   action        = "lambda:${each.value}"
-  function_name = aws_lambda_alias.search_alias.arn
+  function_name = aws_lambda_function.search.function_name
+  qualifier     = aws_lambda_alias.search_alias.name
   principal     = "cloudfront.amazonaws.com"
   source_arn    = aws_cloudfront_distribution.site.arn
 }


### PR DESCRIPTION
The permission was tied into the alias directly.
When new code was deployed to the lambda, terraform
updated the alias which meant that it destroyed and
recreated the permissions and while they were destroyed,
Cloudfront didn’t have permission to invoke the lambda
and the search would fail.

Using a qualifier like this stops the direct dependency on the alias
