### PR TITLE
DR2-2794 Allow searching for file extension.

### DIFF
--- a/.github/scripts/generate_index_file.py
+++ b/.github/scripts/generate_index_file.py
@@ -2,6 +2,7 @@ import json
 import os
 import sqlite3
 import sys
+import uuid
 
 path = sys.argv[1]
 
@@ -17,9 +18,13 @@ def create_table():
     conn = sqlite3.connect("indexes")
     try:
         cursor = conn.cursor()
-        cursor.execute("DROP TABLE IF EXISTS indexes")
+        cursor.execute("DROP TABLE IF EXISTS formats")
+        cursor.execute("DROP TABLE IF EXISTS extensions")
         cursor.execute(
-            "CREATE TABLE IF NOT EXISTS indexes (path, name, extensions, field)"
+            "CREATE TABLE IF NOT EXISTS formats (id, path, name, field)"
+        )
+        cursor.execute(
+            "CREATE TABLE IF NOT EXISTS extensions (name, format_id)"
         )
         conn.commit()
     except sqlite3.Error as e:
@@ -28,17 +33,22 @@ def create_table():
         conn.close()
 
 
-def insert_into_indexes(
-    path_value: str, field_name: str, extensions: str, field_value: str
+def insert_into_database(
+    path_value: str, field_name: str, extension_names: str, field_value: str
 ):
     conn = sqlite3.connect("indexes")
     try:
+        format_id = str(uuid.uuid4())
         cursor = conn.cursor()
         cursor.execute(
-            "INSERT INTO indexes (path, name, extensions, field) VALUES (?, ?, ?, ?)",
-            (path_value, field_name, extensions, field_value),
+            "INSERT INTO formats (id, path, name, field) VALUES (?, ?, ?, ?)",
+            (format_id, path_value, field_name, field_value),
         )
-
+        for extension_name in extension_names:
+            cursor.execute(
+                "INSERT INTO extensions (name, format_id) VALUES (?, ?)",
+                (extension_name, format_id),
+            )
         conn.commit()
     except sqlite3.Error as e:
         print(f"An error occurred: {e}")
@@ -69,9 +79,8 @@ def run():
             ]
             extension_names = [fe["externalSignature"] for fe in file_extension_list]
             file_extension = "".join(extension_names)
-            file_extensions_delimited = ", ".join(extension_names)
             field = "".join([format_name, file_extension])
-            insert_into_indexes(puid, format_name, file_extensions_delimited, field)
+            insert_into_database(puid, format_name, extension_names, field)
 
 
 run()

--- a/.github/scripts/generate_index_file.py
+++ b/.github/scripts/generate_index_file.py
@@ -51,7 +51,7 @@ def insert_into_database(
             )
         conn.commit()
     except sqlite3.Error as e:
-        print(f"An error occurred: {e}")
+        print(f"An error occurred inserting rows: {e}")
     finally:
         conn.close()
 

--- a/lambdas/results/results.py
+++ b/lambdas/results/results.py
@@ -28,7 +28,7 @@ def puid_exists(puid):
     db_name = os.getenv("DB_NAME", "indexes")
     with closing(sqlite3.connect(db_name)) as conn:
         with closing(conn.cursor()) as cur:
-            cur.execute("SELECT path from indexes where path = ?", (puid,))
+            cur.execute("SELECT path from formats where path = ?", (puid,))
             rows = cur.fetchall()
     return len(rows) > 0
 
@@ -41,10 +41,15 @@ def search(search_string):
     db_name = os.getenv("DB_NAME", "indexes")
     with closing(sqlite3.connect(db_name)) as conn:
         with closing(conn.cursor()) as cur:
-            cur.execute(
-                "select path, name, extensions from indexes where field like ?",
-                (f"%{search_string}%",),
-            )
+            base_query = "select path, f.name, group_concat(e.name, ', ') from formats f join extensions e on e.format_id = f.id"
+            group_by = "group by path, f.name"
+            if search_string.startswith("."):
+                cur.execute(f"{base_query} where id in (select format_id from extensions where name = ?) {group_by}", (search_string[1:],))
+            else:
+                cur.execute(
+                    f"{base_query} where field like ? {group_by}",
+                    (f"%{search_string}%",),
+                )
             rows = cur.fetchall()
             rows.sort(key=sort_key)
     return rows

--- a/lambdas/results/results.py
+++ b/lambdas/results/results.py
@@ -43,7 +43,7 @@ def search(search_string):
         with closing(conn.cursor()) as cur:
             base_query = "select path, f.name, group_concat(e.name, ', ') from formats f join extensions e on e.format_id = f.id"
             group_by = "group by path, f.name"
-            if search_string.startswith("."):
+            if search_string.startswith(".") and len(search_string) > 1:
                 cur.execute(f"{base_query} where id in (select format_id from extensions where name = ?) {group_by}", (search_string[1:],))
             else:
                 cur.execute(

--- a/lambdas/results/results.py
+++ b/lambdas/results/results.py
@@ -45,6 +45,8 @@ def search(search_string):
             group_by = "group by path, f.name"
             if search_string.startswith(".") and len(search_string) > 1:
                 cur.execute(f"{base_query} where id in (select format_id from extensions where name = ?) {group_by}", (search_string[1:],))
+            elif search_string.strip() == ".":
+                return []
             else:
                 cur.execute(
                     f"{base_query} where field like ? {group_by}",

--- a/lambdas/test/test_results.py
+++ b/lambdas/test/test_results.py
@@ -14,16 +14,19 @@ class ResultsTest(unittest.TestCase):
     def setUp(self):
         conn = sqlite3.connect(db_name)
         cursor = conn.cursor()
-        cursor.execute("DROP TABLE IF EXISTS indexes")
-        cursor.execute("CREATE TABLE indexes (path, name, extensions, field)")
+        cursor.execute("DROP TABLE IF EXISTS formats")
+        cursor.execute("DROP TABLE IF EXISTS extensions")
+        cursor.execute("CREATE TABLE formats (id, path, name, field)")
+        cursor.execute("CREATE TABLE extensions (name, format_id)")
         insert_sql = (
-            "INSERT INTO indexes (path, name, extensions, field) VALUES (?, ?, ?, ?)"
+            "INSERT INTO formats (id, path, name, field) VALUES (?, ?, ?, ?)"
         )
         for i in range(1, 1001):
             cursor.execute(
                 insert_sql,
-                (f"fmt/{i}", f"Test Name {i}", f"ext{i}", "testsearchstring"),
+                (str(i), f"fmt/{i}", f"Test Name {i}", "testsearchstring"),
             )
+            cursor.execute("INSERT INTO extensions (name, format_id) VALUES (?, ?)", (f"ext{i}", str(i)))
         conn.commit()
 
     def tearDown(self):
@@ -40,6 +43,7 @@ class ResultsTest(unittest.TestCase):
             )
             self.assertTrue(f"<dd>ext{i}</dd>" in response["body"])
 
+
     def test_search_not_found(self):
         response = results.lambda_handler(
             {"queryStringParameters": {"q": "invalid"}}, None
@@ -47,6 +51,14 @@ class ResultsTest(unittest.TestCase):
         self.assertTrue(
             '<h2 class="tna-heading-m">No results found</h2>' in response["body"]
         )
+
+    def test_search_file_extension(self):
+        response = results.lambda_handler(
+            {"queryStringParameters": {"q": ".ext1"}}, None
+        )
+        self.assertEqual(response["statusCode"], 200)
+        self.assertTrue(f"<dd>ext1</dd>" in response["body"])
+
 
     def test_search_existing_fmt(self):
         response = results.lambda_handler(

--- a/lambdas/test/test_results.py
+++ b/lambdas/test/test_results.py
@@ -57,7 +57,15 @@ class ResultsTest(unittest.TestCase):
             {"queryStringParameters": {"q": ".ext1"}}, None
         )
         self.assertEqual(response["statusCode"], 200)
-        self.assertTrue(f"<dd>ext1</dd>" in response["body"])
+        self.assertTrue("<dd>ext1</dd>" in response["body"])
+
+
+    def test_search_single_dot(self):
+        response = results.lambda_handler(
+            {"queryStringParameters": {"q": "."}}, None
+        )
+        self.assertEqual(response["statusCode"], 200)
+        self.assertTrue("No results found" in response["body"])
 
 
     def test_search_existing_fmt(self):

--- a/tests/cypress/e2e/home.cy.ts
+++ b/tests/cypress/e2e/home.cy.ts
@@ -35,6 +35,19 @@ describe("PRONOM Home Spec", () => {
     checkSearchLinks("fmt/1568", "ISDOCX Information System Document 5.x");
   });
 
+  it("submits a an extension search if the search starts with a dot", () => {
+    const checkSearchLinks = (puid: string, name: string): void => {
+      const fmt: Cypress.Chainable<JQuery<HTMLElement>> = cy
+          .get(`a[href='${puid}']`)
+          .last();
+      fmt.should("have.text", name);
+    };
+    cy.get("#search").type(".js");
+    cy.get("form[action='/results']").submit();
+    cy.get(".tna-card__heading").should("have.length", 1)
+    cy.get("a[href='x-fmt/423']").should("have.text", "JavaScript file")
+  });
+
   it("redirects if the search is a valid puid", () => {
     cy.get("#search").type("fmt/1");
     cy.intercept("GET", "/results?q=*").as("results");

--- a/tests/cypress/e2e/home.cy.ts
+++ b/tests/cypress/e2e/home.cy.ts
@@ -35,7 +35,7 @@ describe("PRONOM Home Spec", () => {
     checkSearchLinks("fmt/1568", "ISDOCX Information System Document 5.x");
   });
 
-  it("submits a an extension search if the search starts with a dot", () => {
+  it("submits an extension search if the search starts with a dot", () => {
     const checkSearchLinks = (puid: string, name: string): void => {
       const fmt: Cypress.Chainable<JQuery<HTMLElement>> = cy
           .get(`a[href='${puid}']`)


### PR DESCRIPTION
This was an excuse for a long overdue change to the database. indexes is
now called formats and there is a separate extensions table.

This allows users to search for a specific extension if they prefix it
with a `.`

I've added python and cypress tests to check for this.
