### PR TITLE
DR2-2810 Reduce Cloudfront costs.

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -36,10 +36,11 @@ cd lambdas || exit
 cd soap
 zip -rq ../../soap.zip .
 cd ../../
-zip -q soap.zip version
+aws s3 cp "$S3_URL/signatures/$LATEST_SIGNATURE_FILE" signature-file.xml
+zip -q soap.zip version signature-file.xml
 
 cp ./*.zip terraform
 cd terraform || exit
 terraform init
 TF_VAR_latest_signature_version=$LATEST_SIGNATURE_FILE terraform apply --auto-approve
- aws cloudfront create-invalidation --distribution-id $(aws cloudfront list-distributions --query 'DistributionList.Items[0].Id' --output text) --paths "/*"
+aws cloudfront create-invalidation --distribution-id $(aws cloudfront list-distributions --query 'DistributionList.Items[0].Id' --output text) --paths "/*"

--- a/lambdas/soap/soap.py
+++ b/lambdas/soap/soap.py
@@ -1,7 +1,3 @@
-import os
-import urllib.request
-
-
 def response(contents, content_type="xml"):
     return {
         "statusCode": 200,
@@ -29,6 +25,18 @@ soap_response_suffix = """
   </soap:Body>
 </soap:Envelope>
 """
+
+
+def get_signature_file(headers):
+    with open('signature-file.xml', "r") as sig_file:
+        sig_file_response = sig_file.read()
+    if 'range' in headers:
+        range_bytes = headers["range"].split("=")[1]
+        range_start = int(range_bytes.split("-")[0])
+        range_end = int(range_bytes.split("-")[1])
+        return sig_file_response[range_start:range_end]
+    else:
+        return sig_file_response
 
 
 def lambda_handler(event, context):
@@ -61,18 +69,18 @@ def lambda_handler(event, context):
             with open("version") as version_file:
                 return response(version_file.read())
         elif "http://pronom.nationalarchives.gov.uk:getSignatureFileV1In" in action:
-            ff_signature_xml = (
-                urllib.request.urlopen(os.environ["DOWNLOAD_URL"])
-                .read()
-                .decode("utf-8")
-            )
-            xml_without_declaration = ff_signature_xml.replace(
-                '<?xml version="1.0" encoding="UTF-8"?>', ""
-            )
-            response_xml = (
-                soap_response_prefix + xml_without_declaration + soap_response_suffix
-            )
-            print(len(response_xml))
-            return response(response_xml)
+            ff_signature_xml = get_signature_file(headers)
+            if len(ff_signature_xml) > 1:
+                xml_without_declaration = ff_signature_xml.replace(
+                    '<?xml version="1.0" encoding="UTF-8"?>', ""
+                )
+                response_xml = (
+                    soap_response_prefix + xml_without_declaration + soap_response_suffix
+                )
+                print(f"Returning response of size {len(response_xml)}")
+                return response(response_xml)
+            else:
+                print(f"Returning response of size {len(ff_signature_xml)}")
+                return response(ff_signature_xml)
         else:
             return {"statusCode": 404}

--- a/lambdas/test/test_soap.py
+++ b/lambdas/test/test_soap.py
@@ -19,6 +19,8 @@ class SoapTest(unittest.TestCase):
             return mock_open(
                 read_data="Test signature file version description"
             ).return_value
+        elif file == "signature-file.xml":
+            return mock_open(read_data="Test String").return_value
         else:
             return mock_open(read_data="Test wsdl").return_value
 
@@ -32,12 +34,8 @@ class SoapTest(unittest.TestCase):
         )
         self.assertEqual(response["statusCode"], 404)
 
-    @patch("urllib.request.urlopen")
-    def test_return_downloaded_file(self, mock_urlopen):
-        os.environ["DOWNLOAD_URL"] = "http://example.com/test"
-        mock_response = Mock()
-        mock_response.read.return_value = b"Test String"
-        mock_urlopen.return_value = mock_response
+    @patch("builtins.open", side_effect=open_mock_file)
+    def test_return_downloaded_file(self, _):
         action = "http://pronom.nationalarchives.gov.uk:getSignatureFileV1In"
         response = soap.lambda_handler(
             {"requestContext": {"http": {"method": "POST"}}, "headers": {"soapaction": action}}, None
@@ -54,6 +52,18 @@ Test String
   </soap:Body>
 </soap:Envelope>
 """
+        self.assertEqual(response["statusCode"], 200)
+        self.assertEqual(response["body"], expected_body)
+        self.assertEqual(response["headers"]["Content-Type"], "text/xml")
+
+    @patch("builtins.open", side_effect=open_mock_file)
+    def test_return_downloaded_file_with_range(self, _):
+        action = "http://pronom.nationalarchives.gov.uk:getSignatureFileV1In"
+        response = soap.lambda_handler(
+            {"requestContext": {"http": {"method": "POST"}}, "headers": {"range": "bytes=0-1", "soapaction": action}}, None
+        )
+
+        expected_body = "T"
         self.assertEqual(response["statusCode"], 200)
         self.assertEqual(response["body"], expected_body)
         self.assertEqual(response["headers"]["Content-Type"], "text/xml")

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -82,11 +82,6 @@ resource "aws_lambda_function" "soap" {
   timeout                        = 60
   reserved_concurrent_executions = local.lambda_reserved_concurrent_executions
   source_code_hash               = filebase64sha256("${path.module}/soap.zip")
-  environment {
-    variables = {
-      DOWNLOAD_URL = "https://pronom.nationalarchives.gov.uk/signatures/${var.latest_signature_version}"
-    }
-  }
 }
 
 data "archive_file" "edge_lambda_code" {


### PR DESCRIPTION
This was originally getting the signature file from the URL so we were
streaming the file from /signatures/DROID_SignatureFile_xxx.xml and
sending it in the response for /service.asmx so we're being charged
twice.

The other problem is that StatusCake is pinging this every minute and
downloading nearly 2Mb each time.

The release process now gets the file from S3 and packages it into the
lambda zip. Then when someone requests the file, it's read from the
lambda file system.

I've added support for the range header as well. StatusCake will send
`Range: bytes=0-1` which will only return the first byte of the
response. Without the range header, you get the whole file.
