### PR TITLE
Improve file extension display and other details summary items

### DIFF
--- a/.github/scripts/generate_pages.py
+++ b/.github/scripts/generate_pages.py
@@ -26,30 +26,22 @@ bucket_name = "tna-pronom-signatures-spike"
 
 
 def get_summary(data):
-    identifiers = ", ".join(
-        [
-            f"{identifier['identifierType']}: {identifier['identifierText']}"
-            for identifier in data["identifiers"]
-        ]
-    )
+    identifiers = {
+        identifier['identifierType']: identifier['identifierText']
+        for identifier in data["identifiers"]
+    } if "identifiers" in data else None
 
-    def str_for_attr(attr):
-        if attr in data:
-            if data[attr] == "":
-                return None
-            else:
-                return data[attr]
-        return None
+    format_types = data.get("formatTypes", None)
 
     return {
-        "Name": str_for_attr("formatName"),
-        "Version": str_for_attr("version"),
+        "Name": data.get("formatName", None),
+        "Version": data.get("version", None),
         "Identifiers": identifiers,
-        "Format Type": str_for_attr("formatTypes"),
-        "Family": str_for_attr("formatFamilies"),
-        "Disclosure": str_for_attr("formatDisclosure"),
-        "Description": str_for_attr("formatDescription"),
-        "Note": str_for_attr("formatNote"),
+        "Format Type": format_types.split(", ") if format_types else None,
+        "Family": data.get("formatFamilies", None),
+        "Disclosure": data.get("formatDisclosure", None),
+        "Description": data.get("formatDescription", None),
+        "Note": data.get("formatNote", None),
     }
 
 
@@ -85,7 +77,7 @@ def get_file_extensions(json_data):
         x for x in external_signatures if x["signatureType"] == "File extension"
     ]
     extension_names = [fe["externalSignature"] for fe in file_extension_list]
-    return ", ".join(extension_names) if extension_names else None
+    return [extension for extension in extension_names if extension]
 
 
 def create_detail(json_data, all_actors, json_by_id):

--- a/.github/scripts/generate_pages.py
+++ b/.github/scripts/generate_pages.py
@@ -26,10 +26,14 @@ bucket_name = "tna-pronom-signatures-spike"
 
 
 def get_summary(data):
-    identifiers = {
-        identifier['identifierType']: identifier['identifierText']
-        for identifier in data["identifiers"]
-    } if "identifiers" in data else None
+    identifiers = (
+        {
+            identifier["identifierType"]: identifier["identifierText"]
+            for identifier in data["identifiers"]
+        }
+        if "identifiers" in data
+        else None
+    )
 
     format_types = data.get("formatTypes", None)
 

--- a/lambdas/templates/details.html
+++ b/lambdas/templates/details.html
@@ -95,21 +95,50 @@
       <dl class="tna-dl tna-dl--lined">
         {%- for result in summary.results %}
           {%- for key, value in result.items() %}
-            {%- if value is defined and value is not none %}
+            {%- if value %}
               <dt>
-                <span class="tna-dl__sticky-title">{{ key }}</span>
+                <span class="tna-dl__sticky-title">{{ key|capitalize }}</span>
               </dt>
-              <dd>{{ value|urlize(nofollow=True) }}</dd>
+              <dd>
+                {%- if value is iterable and not value is string %}
+                  {%- if (value|length > 1) %}
+                    <ul class="tna-ul">
+                    {%- if value is mapping %}
+                      {%- for key, item in value.items() %}
+                        <li><strong>{{ key }}</strong>: {{ item|urlize(nofollow=True) }}</li>
+                      {%- endfor %}
+                    {%- else %}
+                      {%- for item in value %}
+                        <li>{{ item|urlize(nofollow=True) }}</li>
+                      {%- endfor %}
+                    {%- endif %}
+                    </ul>
+                  {%- elif value is mapping %}
+                    {%- for key, item in value.items() %}
+                      <strong>{{ key }}</strong>: {{ item|urlize(nofollow=True) }}
+                    {%- endfor %}
+                  {%- else %}
+                    {%- for item in value %}
+                      {{ item|urlize(nofollow=True) }}
+                    {%- endfor %}
+                  {%- endif %}
+                {%- else %}
+                  {{ value|urlize(nofollow=True) }}
+                {%- endif %}
+              </dd>
             {%- endif %}
           {%- endfor %}
         {%- endfor %}
 
-        {%- if summary.extensions is defined and summary.extensions is not none %}
+        {%- if summary.extensions %}
           <dt>
             <span class="tna-dl__sticky-title">File extensions</span>
           </dt>
           <dd>
-            <code>{{ summary.extensions }}</code>
+            {%- for extension in summary.extensions %}
+              <code>{{ extension }}</code>
+              {%- if not loop.last %}, {% endif %}
+            {%- endfor %}
           </dd>
         {%- endif %}
 

--- a/lambdas/templates/search_results.html
+++ b/lambdas/templates/search_results.html
@@ -74,7 +74,12 @@
               <code>{{ result.puid }}</code>
             </dd>
             <dt>File extensions</dt>
-            <dd>{{ result.extensions }}</dd>
+            <dd>
+            {%- for extension in result.extensions.split(',') | select %}
+              <code>{{ extension|trim }}</code>
+              {%- if not loop.last %}, {% endif %}
+            {%- endfor %}
+            </dd>
           </dl>
         </li>
         {%- endfor %}

--- a/lambdas/test/test_results.py
+++ b/lambdas/test/test_results.py
@@ -37,18 +37,18 @@ class ResultsTest(unittest.TestCase):
             {"queryStringParameters": {"q": "search"}}, None
         )
         for i in range(1, 1001):
-            self.assertTrue(
-                f'<a href="fmt/{i}" class="pronom-results__item-heading">Test Name {i}</a>'
-                in response["body"]
+            self.assertIn(
+                f'<a href="fmt/{i}" class="pronom-results__item-heading">Test Name {i}</a>',
+                response["body"],
             )
-            self.assertTrue(f"<dd><code>ext{i}</code></dd>" in response["body"])
+            self.assertIn(f"<code>ext{i}</code>", response["body"])
 
     def test_search_not_found(self):
         response = results.lambda_handler(
             {"queryStringParameters": {"q": "invalid"}}, None
         )
-        self.assertTrue(
-            '<h2 class="tna-heading-m">No results found</h2>' in response["body"]
+        self.assertIn(
+            '<h2 class="tna-heading-m">No results found</h2>', response["body"]
         )
 
     def test_search_file_extension(self):
@@ -56,12 +56,12 @@ class ResultsTest(unittest.TestCase):
             {"queryStringParameters": {"q": ".ext1"}}, None
         )
         self.assertEqual(response["statusCode"], 200)
-        self.assertTrue("<dd>ext1</dd>" in response["body"])
+        self.assertIn("<code>ext1</code>", response["body"])
 
     def test_search_single_dot(self):
         response = results.lambda_handler({"queryStringParameters": {"q": "."}}, None)
         self.assertEqual(response["statusCode"], 200)
-        self.assertTrue("No results found" in response["body"])
+        self.assertIn("No results found", response["body"])
 
     def test_search_existing_fmt(self):
         response = results.lambda_handler(
@@ -81,6 +81,6 @@ class ResultsTest(unittest.TestCase):
         response = results.lambda_handler(
             {"queryStringParameters": {"q": "fmt/3210"}}, None
         )
-        self.assertTrue(
-            '<h2 class="tna-heading-m">No results found</h2>' in response["body"]
+        self.assertIn(
+            '<h2 class="tna-heading-m">No results found</h2>', response["body"]
         )

--- a/lambdas/test/test_results.py
+++ b/lambdas/test/test_results.py
@@ -41,7 +41,7 @@ class ResultsTest(unittest.TestCase):
                 f'<a href="fmt/{i}" class="pronom-results__item-heading">Test Name {i}</a>'
                 in response["body"]
             )
-            self.assertTrue(f"<dd>ext{i}</dd>" in response["body"])
+            self.assertTrue(f"<dd><code>ext{i}</code></dd>" in response["body"])
 
     def test_search_not_found(self):
         response = results.lambda_handler(

--- a/tests/cypress/e2e/view_format.cy.ts
+++ b/tests/cypress/e2e/view_format.cy.ts
@@ -19,7 +19,7 @@ describe("PRONOM View Format Spec", () => {
         expect(summaryFields["Name"]).to.equal("Microsoft Visio Drawing");
         expect(summaryFields["Version"]).to.equal("3");
         expect(summaryFields["Identifiers"]).to.equal(
-          "MIME: application/vnd.visio, PUID: fmt/1509",
+          "MIME: application/vnd.visio\n                        PUID: fmt/1509",
         );
         expect(summaryFields["Format Type"]).to.equal("Image (Vector)");
         expect(summaryFields["Description"]).to.equal(

--- a/tests/cypress/e2e/view_format.cy.ts
+++ b/tests/cypress/e2e/view_format.cy.ts
@@ -21,7 +21,7 @@ describe("PRONOM View Format Spec", () => {
         expect(summaryFields["Identifiers"]).to.equal(
           "MIME: application/vnd.visio\n                        PUID: fmt/1509",
         );
-        expect(summaryFields["Format Type"]).to.equal("Image (Vector)");
+        expect(summaryFields["Format type"]).to.equal("Image (Vector)");
         expect(summaryFields["Description"]).to.equal(
           "Microsoft Visio is a diagramming and vector graphics application and is part of the Microsoft Office family.",
         );


### PR DESCRIPTION
- Details with multiple items get rendered as a list
- Field names are capitalised (no uppercase "T" on "Format types"
- Extensions are separated
- Keyed details (i.e. `dict` rather than `list`) get shown as key/value lists
- Extensions in search results get the same fix applied
- Simplification/removal of `str_for_attr`

Before
<img width="2546" height="2576" alt="before" src="https://github.com/user-attachments/assets/419aae8f-93e1-4618-a02f-076e17d5fa91" />

After
<img width="2546" height="2576" alt="after" src="https://github.com/user-attachments/assets/254eaaa0-fa9e-45d6-9e67-bb46da0e60c4" />
