### PR TITLE
Add permissions to allow assume role in the prod release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,9 @@ jobs:
       - e2e-tests
     if: ${{ needs.e2e-tests.result == 'success' }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     name: Release production
     environment:
       name: production


### PR DESCRIPTION
The token permissions are set for each job, we missed these ones for the prod release.
