### PR TITLE
DR2-2887 Handle different header cases

### DIFF
--- a/lambdas/soap/soap.py
+++ b/lambdas/soap/soap.py
@@ -66,17 +66,17 @@ def lambda_handler(event, context):
         else:
             return file_response("soap_description.html")
     else:
-        headers = event["headers"]
+        headers = {k.lower(): v for k, v in event["headers"].items()}
         if "soapaction" not in headers:
             return {"statusCode": 404}
-        action = headers["soapaction"]
+        action = headers["soapaction"].lower()
         if (
-            "http://pronom.nationalarchives.gov.uk:getSignatureFileVersionV1In"
+            "http://pronom.nationalarchives.gov.uk:getsignaturefileversionv1in"
             in action
         ):
             with open("version") as version_file:
                 return response(version_file.read())
-        if "http://pronom.nationalarchives.gov.uk:getSignatureFileV1In" in action:
+        if "http://pronom.nationalarchives.gov.uk:getsignaturefilev1in" in action:
             ff_signature_xml = get_signature_file(headers)
             if len(ff_signature_xml) > 1:
                 xml_without_declaration = ff_signature_xml.replace(

--- a/lambdas/test/test_soap.py
+++ b/lambdas/test/test_soap.py
@@ -6,6 +6,20 @@ from lambdas.soap import soap
 
 class SoapTest(unittest.TestCase):
     @staticmethod
+    def expected_body():
+        return """<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body>
+    <getSignatureFileV1Response xmlns="http://pronom.nationalarchives.gov.uk">
+      <SignatureFile>
+Test String
+      </SignatureFile>
+    </getSignatureFileV1Response>
+  </soap:Body>
+</soap:Envelope>
+"""
+
+    @staticmethod
     def open_mock_file(file, *args, **kwargs):
         if file == "version":
             return mock_open(read_data="Test version file content").return_value
@@ -49,19 +63,23 @@ class SoapTest(unittest.TestCase):
             None,
         )
 
-        expected_body = """<?xml version="1.0" encoding="utf-8"?>
-<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <soap:Body>
-    <getSignatureFileV1Response xmlns="http://pronom.nationalarchives.gov.uk">
-      <SignatureFile>
-Test String
-      </SignatureFile>
-    </getSignatureFileV1Response>
-  </soap:Body>
-</soap:Envelope>
-"""
         self.assertEqual(response["statusCode"], 200)
-        self.assertEqual(response["body"], expected_body)
+        self.assertEqual(response["body"], self.expected_body())
+        self.assertEqual(response["headers"]["Content-Type"], "text/xml")
+
+    @patch("builtins.open", side_effect=open_mock_file)
+    def test_return_downloaded_file_with_different_case(self, _):
+        action = "http://pronom.nationalarchives.gov.uk:GetSignatureFilev1IN"
+        response = soap.lambda_handler(
+            {
+                "requestContext": {"http": {"method": "POST"}},
+                "headers": {"soapAction": action},
+            },
+            None,
+        )
+
+        self.assertEqual(response["statusCode"], 200)
+        self.assertEqual(response["body"], self.expected_body())
         self.assertEqual(response["headers"]["Content-Type"], "text/xml")
 
     @patch("builtins.open", side_effect=open_mock_file)
@@ -87,6 +105,20 @@ Test String
             {
                 "requestContext": {"http": {"method": "POST"}},
                 "headers": {"soapaction": action},
+            },
+            None,
+        )
+        self.assertEqual(response["body"], "Test version file content")
+        self.assertEqual(response["headers"]["Content-Type"], "text/xml")
+        self.assertEqual(response["statusCode"], 200)
+
+    @patch("builtins.open", side_effect=open_mock_file)
+    def test_return_version_file_with_different_case(self, _):
+        action = "http://pronom.nationalarchives.gov.uk:GetSignaturefileVersionv1IN"
+        response = soap.lambda_handler(
+            {
+                "requestContext": {"http": {"method": "POST"}},
+                "headers": {"SOAPAction": action},
             },
             None,
         )


### PR DESCRIPTION
Before, we were using lambda@edge to add the sha256 header to the reqeuest.
Using lambda@edge lower cases all of the headers going to the lambda function
via the function URL.

We’re now using API gateway which doesn’t do this. The header as written on
the service page is SOAPAction which is what statuscake is using but the
lambda is still expecting soapaction.

We need to change the lambda to accept any case.
