### PR TITLE
Add GITHUB_TOKEN environment variable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,8 @@ jobs:
           npx cypress run
           cd ..
           docker compose exec app poetry run python -m unittest discover -v -s lambdas/test
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
   check-formatting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The docker build is set up to use the token but we're not actually passing it in. This should help.
